### PR TITLE
Add MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.md setup.py setup.cfg
+recursive-include *.py
+global-exclude *.pyc
+global-exclude *.pyo


### PR DESCRIPTION
fixes #3 

Add in `MANIFEST.in` file to denote which files should be included in the package when it is built `python setup.py sdist`.

