### PR TITLE
Fix syntax error in batch code sample

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ Changes introduced in version 0.0.3 are not backwards compatible.
     
     # for batched calls - a list of tuples like (endpoint, {params})
     >>> batch_calls = [
-            ('disposable', {'email', 'this-is-a-fake-email@fake.com'}),
-            ('person', {'email', 'email@gmail.com'),
+            ('disposable', {'email': 'this-is-a-fake-email@fake.com'}),
+            ('person', {'email': 'email@gmail.com'}),
             ...
         ]
     >>> r2 = fc.api_batch(batch_calls)


### PR DESCRIPTION
I got error when I use the sample and I found the error.
I fix it so other people won't get caught on the same mistake as me.

@garbados, please approve